### PR TITLE
Fix CI

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -44,7 +44,7 @@
     "typescript": "5.3.3"
   },
   "scripts": {
-    "build": "tsc && rollup -c && node --test dist"
+    "build": "tsc && rollup -c && node --test dist/index.test.mjs"
   },
   "eslintConfig": {
     "root": true,

--- a/packages/lifetimes/package.json
+++ b/packages/lifetimes/package.json
@@ -25,7 +25,7 @@
     }
   },
   "scripts": {
-    "build": "tsc && rollup -c && node --test dist"
+    "build": "tsc && rollup -c && node --test dist/lifetimes.test.js"
   },
   "files": [
     "dist/lifetimes.d.ts",


### PR DESCRIPTION
Node 21 CI is broken because of this semver-major change: https://github.com/nodejs/node/pull/47653 

Accordingly, we need to specifically name test files for node 21 cli compat.