### PR TITLE
Readonly improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.0] - 2024-04-24
+
+- MINOR: Accept inline non-function wrapped parameters to `readOnly`
+- MINOR: Avoid using proxies in `readOnly` for non-complex values
+- MINOR: Eagerly mark objects and arrays as immutable in `readOnly`
+
 ## [2.0.0] - 2024-04-09
 
 - MAJOR Don't transitively apply immutability to results of method calls of immutable values

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The second rule is where the complexity comes in: obviously there need to be exc
 ```
 import { readOnly } from 'lifetimes';
 
-const RETRY_TIMEOUTS = readOnly(() => [50, 100, 250, 500, 1000]);
+const RETRY_TIMEOUTS = readOnly([50, 100, 250, 500, 1000]);
+const VALID_INPUTS = readOnly(() => new Set(['foo', 'bar']));
 ```
 
 `requestLocal`: Call .get() to access the current instance of the value

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifetimes/eslint-plugin",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Marcus Armstrong <marcusdarmstrong@gmail.com>",
   "homepage": "https://github.com/marcusdarmstrong/lifetimes",
   "repository": "github:marcusdarmstrong/lifetimes",

--- a/packages/lifetimes/package.json
+++ b/packages/lifetimes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifetimes",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A utility for explicit specification and enforcement of module scope variable lifetimes",
   "license": "MIT",
   "author": "Marcus Armstrong <marcusdarmstrong@gmail.com>",


### PR DESCRIPTION
Allow `readOnly` to accept non-function wrapped values, e.g. `readOnly([1, 2, 3]);`. In doing so, also be less aggressive about using proxies to optimize the overhead of these calls. Instead, we'll rely on a deep-freeze-style mechanism unless we need to deopt to the proxy.