### PR TITLE
React support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.0] - 2024-04-29
+
+- MINOR: Add explicit support for React-specific objects in `readOnly`
+
 ## [2.1.0] - 2024-04-24
 
 - MINOR: Accept inline non-function wrapped parameters to `readOnly`

--- a/package-lock.json
+++ b/package-lock.json
@@ -687,6 +687,22 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.12",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.79",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.79.tgz",
+      "integrity": "sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -1096,6 +1112,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1752,6 +1774,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1820,6 +1848,18 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -2047,6 +2087,18 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -2399,7 +2451,7 @@
     },
     "packages/eslint-plugin": {
       "name": "@lifetimes/eslint-plugin",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": ">=6.8.0"
@@ -2429,7 +2481,7 @@
       }
     },
     "packages/lifetimes": {
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-eslint": "9.0.5",
@@ -2439,11 +2491,13 @@
         "@tsconfig/node16": "16.1.1",
         "@tsconfig/strictest": "2.0.3",
         "@types/node": "20.11.24",
+        "@types/react": "18.2.79",
         "@typescript-eslint/eslint-plugin": "7.1.1",
         "@typescript-eslint/parser": "7.1.1",
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "5.1.3",
+        "react": "18.2.0",
         "rollup": "4.12.0",
         "typescript": "5.3.3"
       },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifetimes/eslint-plugin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "Marcus Armstrong <marcusdarmstrong@gmail.com>",
   "homepage": "https://github.com/marcusdarmstrong/lifetimes",
   "repository": "github:marcusdarmstrong/lifetimes",

--- a/packages/lifetimes/lifetimes.ts
+++ b/packages/lifetimes/lifetimes.ts
@@ -1,6 +1,8 @@
 import type { AsyncLocalStorage } from "node:async_hooks";
 import { createScope } from "#scope";
 
+import type { ReactElement } from "react";
+
 const MUTABLE_SET_METHODS = new Set<string | symbol>([
   "add",
   "delete",
@@ -26,13 +28,22 @@ const MUTABLE_DATE_METHODS = new Set<string | symbol>([
   "setYear",
 ]);
 
-function immutableProxy<T>(value: T): T {
+function isReactObject(value: unknown): boolean {
+  return (
+    (typeof value === "object" || typeof value === "function") &&
+    value !== null &&
+    "$$typeof" in value
+  );
+}
+
+function immutableProxy<T>(value: T): Immutable<T> {
   if (
+    isReactObject(value) ||
     (typeof value !== "object" && typeof value !== "function") ||
     value === null
   ) {
     // Primitive values are implicitly immutable.
-    return value;
+    return value as Immutable<T>;
   }
 
   if (value instanceof Promise) {
@@ -41,13 +52,7 @@ function immutableProxy<T>(value: T): T {
     );
   }
 
-  // This effectively prevents mutation of arrays and objects.
   Object.preventExtensions(value);
-  Reflect.ownKeys(value).forEach((property) => {
-    Object.defineProperty(value, property, {
-      writable: false,
-    });
-  });
 
   return new Proxy(value, {
     get(target, property, receiver) {
@@ -69,30 +74,28 @@ function immutableProxy<T>(value: T): T {
           : returnValue,
       );
     },
-  });
+  }) as Immutable<T>;
 }
 
-function makeImmutable<T>(value: T): T {
+function makeImmutable<T>(value: T): Immutable<T> {
   if (
     value instanceof Promise ||
     value instanceof Set ||
     value instanceof Map ||
-    value instanceof Date
+    value instanceof Date ||
+    isReactObject(value)
   ) {
     return immutableProxy(value);
   }
 
   if (typeof value === "object" && value !== null) {
-    Object.preventExtensions(value);
     Reflect.ownKeys(value).forEach((property) => {
-      Object.defineProperty(value, property, {
-        writable: false,
-      });
       makeImmutable(value[property as keyof typeof value]);
     });
+    Object.freeze(value);
   }
 
-  return value;
+  return value as Immutable<T>;
 }
 
 export type ReadonlyDate = Readonly<
@@ -124,14 +127,19 @@ export type Immutable<T> = T extends (...args: infer Ks) => infer V
       ? ReadonlySet<Immutable<S>>
       : T extends Map<infer K, infer V>
         ? ReadonlyMap<Immutable<K>, Immutable<V>>
-        : {
-            readonly [K in keyof T]: Immutable<T[K]>;
-          };
+        : T extends ReactElement<unknown>
+          ? T
+          : {
+              readonly [K in keyof T]: Immutable<T[K]>;
+            };
 
-function isCallable(value: unknown): value is (...args: unknown[]) => unknown {
+function isCallable<T>(
+  value: ReadOnlyInitializer<T>,
+): value is ClosureInitializer<T> {
   return typeof value === "function";
 }
 
+/*
 export function readOnly<T>(
   initializer: () => T extends Promise<unknown> ? never : T,
 ): Immutable<T>;
@@ -141,7 +149,16 @@ export function readOnly<T>(
     : T extends Promise<unknown>
       ? never
       : T,
-): Immutable<T>;
+): Immutable<T>; */
+
+type ClosureInitializer<T> = () => T extends Promise<unknown> ? never : T;
+type InlineInitializer<T> = T extends (...args: unknown[]) => unknown
+  ? never
+  : T extends Promise<unknown>
+    ? never
+    : T;
+
+type ReadOnlyInitializer<T> = ClosureInitializer<T> | InlineInitializer<T>;
 
 /**
  * Mark the lifetime of a provided block of code as "forever" with safety
@@ -151,7 +168,7 @@ export function readOnly<T>(
  * @return The provided callback's return value, frozen, and wrapped in a
  *  readOnly-enforcing Proxy.
  */
-export function readOnly<T>(initializer: T | (() => T)): T {
+export function readOnly<T>(initializer: ReadOnlyInitializer<T>): Immutable<T> {
   if (isCallable(initializer)) {
     return makeImmutable(initializer());
   }

--- a/packages/lifetimes/lifetimes.ts
+++ b/packages/lifetimes/lifetimes.ts
@@ -139,18 +139,6 @@ function isCallable<T>(
   return typeof value === "function";
 }
 
-/*
-export function readOnly<T>(
-  initializer: () => T extends Promise<unknown> ? never : T,
-): Immutable<T>;
-export function readOnly<T>(
-  initializer: T extends (...args: unknown[]) => unknown
-    ? never
-    : T extends Promise<unknown>
-      ? never
-      : T,
-): Immutable<T>; */
-
 type ClosureInitializer<T> = () => T extends Promise<unknown> ? never : T;
 type InlineInitializer<T> = T extends (...args: unknown[]) => unknown
   ? never

--- a/packages/lifetimes/package.json
+++ b/packages/lifetimes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifetimes",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A utility for explicit specification and enforcement of module scope variable lifetimes",
   "license": "MIT",
   "author": "Marcus Armstrong <marcusdarmstrong@gmail.com>",
@@ -43,11 +43,13 @@
     "@tsconfig/strictest": "2.0.3",
     "@tsconfig/node16": "16.1.1",
     "@types/node": "20.11.24",
+    "@types/react": "18.2.79",
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.1.3",
+    "react": "18.2.0",
     "rollup": "4.12.0",
     "typescript": "5.3.3"
   },

--- a/packages/lifetimes/rollup.config.js
+++ b/packages/lifetimes/rollup.config.js
@@ -44,5 +44,5 @@ export default [{
   output: output("test"),
   plugins: plugins("node"),
   // plugin-node-resolve uses an out-of-date builtins list.
-  external: ["node:test"],
+  external: ["node:test", "react"],
 }];


### PR DESCRIPTION
Adds specific support to prevent typescript from blowing up on `lazy` components passed into `readOnly`, as well as to avoid React blowing up on deep freezes of React elements.