### PR TITLE
Add support for 'nested' ReadonlyDates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2451,7 +2451,7 @@
     },
     "packages/eslint-plugin": {
       "name": "@lifetimes/eslint-plugin",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": ">=6.8.0"
@@ -2481,7 +2481,7 @@
       }
     },
     "packages/lifetimes": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-eslint": "9.0.5",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifetimes/eslint-plugin",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Marcus Armstrong <marcusdarmstrong@gmail.com>",
   "homepage": "https://github.com/marcusdarmstrong/lifetimes",
   "repository": "github:marcusdarmstrong/lifetimes",

--- a/packages/lifetimes/lifetimes.test.ts
+++ b/packages/lifetimes/lifetimes.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import { lazy, createElement } from "react";
 
 import {
+  type ReadonlyDate,
   readOnly,
   requestLocal,
   unsafeSingleton,
@@ -210,6 +211,8 @@ test("readOnly", async (t) => {
       // @ts-expect-error: This is readonly, of course.
       date.setMonth(0);
     }, "cannot be modified");
+
+    readOnly(() => date) satisfies ReadonlyDate;
   });
 
   await t.test("promises", () => {

--- a/packages/lifetimes/lifetimes.ts
+++ b/packages/lifetimes/lifetimes.ts
@@ -14,18 +14,22 @@ const MUTABLE_MAP_METHODS = new Set<string | symbol>([
   "clear",
 ]);
 const MUTABLE_DATE_METHODS = new Set<string | symbol>([
-  "setDate",
-  "setFullYear",
-  "setHours",
-  "setMilliseconds",
-  "setMinutes",
-  "setMonth",
-  "setSeconds",
   "setTime",
-  "setUTCDate",
-  "setUTCFullYear",
-  "setUTCHours",
   "setYear",
+  "setMilliseconds",
+  "setUTCMilliseconds",
+  "setSeconds",
+  "setUTCSeconds",
+  "setMinutes",
+  "setUTCMinutes",
+  "setHours",
+  "setUTCHours",
+  "setDate",
+  "setUTCDate",
+  "setMonth",
+  "setUTCMonth",
+  "setFullYear",
+  "setUTCFullYear",
 ]);
 
 function isReactObject(value: unknown): boolean {
@@ -102,6 +106,7 @@ export type ReadonlyDate = Readonly<
   Omit<
     Date,
     | "setTime"
+    | "setYear"
     | "setMilliseconds"
     | "setUTCMilliseconds"
     | "setSeconds"
@@ -123,15 +128,17 @@ export type Immutable<T> = T extends (...args: infer Ks) => infer V
   ? (...args: Ks) => V
   : T extends Date
     ? ReadonlyDate
-    : T extends Set<infer S>
-      ? ReadonlySet<Immutable<S>>
-      : T extends Map<infer K, infer V>
-        ? ReadonlyMap<Immutable<K>, Immutable<V>>
-        : T extends ReactElement<unknown>
-          ? T
-          : {
-              readonly [K in keyof T]: Immutable<T[K]>;
-            };
+    : T extends ReadonlyDate
+      ? ReadonlyDate
+      : T extends Set<infer S>
+        ? ReadonlySet<Immutable<S>>
+        : T extends Map<infer K, infer V>
+          ? ReadonlyMap<Immutable<K>, Immutable<V>>
+          : T extends ReactElement<unknown>
+            ? T
+            : {
+                readonly [K in keyof T]: Immutable<T[K]>;
+              };
 
 function isCallable<T>(
   value: ReadOnlyInitializer<T>,

--- a/packages/lifetimes/package.json
+++ b/packages/lifetimes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifetimes",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A utility for explicit specification and enforcement of module scope variable lifetimes",
   "license": "MIT",
   "author": "Marcus Armstrong <marcusdarmstrong@gmail.com>",


### PR DESCRIPTION
Fixes:
```
error TS1360: Type '{ readonly [Symbol.toPrimitive]: (hint: string) => string | number; readonly toString: () => string; readonly toDateString: () => string; readonly toTimeString: () => string; readonly toLocaleString: (locales?: LocalesArgument, options?: DateTimeFormatOptions | undefined) => string; ... 23 more ...; readonly toJSON:...' does not satisfy the expected type 'Readonly<Omit<Date, "setTime" | "setYear" | "setMilliseconds" | "setUTCMilliseconds" | "setSeconds" | "setUTCSeconds" | "setMinutes" | "setUTCMinutes" | "setHours" | "setUTCHours" | ... 5 more ... | "setUTCFullYear">>'.
  The types returned by '[Symbol.toPrimitive](...)' are incompatible between these types.
    Type 'string | number' is not assignable to type 'string'.
      Type 'number' is not assignable to type 'string'.
```
When `readOnly`-ing a ReadonlyDate:
```
 readOnly(() => date) satisfies ReadonlyDate;
```

Additionally fixes up runtime list of mutable date methods.