### PR TITLE
Add support for const inferrence on readOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.0] - 2024-06-06
+
+- MINOR: Add support const inference on values passed to `readOnly`
+
 ## [2.3.0] - 2024-06-04
 
 - MINOR: Add support for `as` expressions in inline arguments to `readOnly`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2488,7 +2488,7 @@
     },
     "packages/eslint-plugin": {
       "name": "@lifetimes/eslint-plugin",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": ">=6.8.0"
@@ -2518,7 +2518,7 @@
       }
     },
     "packages/lifetimes": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-eslint": "9.0.5",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifetimes/eslint-plugin",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": "Marcus Armstrong <marcusdarmstrong@gmail.com>",
   "homepage": "https://github.com/marcusdarmstrong/lifetimes",
   "repository": "github:marcusdarmstrong/lifetimes",

--- a/packages/lifetimes/lifetimes.test.ts
+++ b/packages/lifetimes/lifetimes.test.ts
@@ -13,6 +13,12 @@ import {
 } from "./lifetimes.ts";
 
 test("readOnly", async (t) => {
+  t.test("const types", () => {
+    type Union = "a" | "b";
+    const a = readOnly("a");
+    a satisfies Union;
+  });
+
   await t.test("objects", () => {
     type Obj = {
       foo: boolean;

--- a/packages/lifetimes/lifetimes.ts
+++ b/packages/lifetimes/lifetimes.ts
@@ -163,7 +163,9 @@ type ReadOnlyInitializer<T> = ClosureInitializer<T> | InlineInitializer<T>;
  * @return The provided callback's return value, frozen, and wrapped in a
  *  readOnly-enforcing Proxy.
  */
-export function readOnly<T>(initializer: ReadOnlyInitializer<T>): Immutable<T> {
+export function readOnly<const T>(
+  initializer: ReadOnlyInitializer<T>,
+): Immutable<T> {
   if (isCallable(initializer)) {
     return makeImmutable(initializer());
   }

--- a/packages/lifetimes/package.json
+++ b/packages/lifetimes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifetimes",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "A utility for explicit specification and enforcement of module scope variable lifetimes",
   "license": "MIT",
   "author": "Marcus Armstrong <marcusdarmstrong@gmail.com>",


### PR DESCRIPTION
Matching the semantics of Object.freeze.