### PR TITLE
Improve behavior for .size, RegExps, and React ComponentTypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2488,7 +2488,7 @@
     },
     "packages/eslint-plugin": {
       "name": "@lifetimes/eslint-plugin",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": ">=6.8.0"
@@ -2518,7 +2518,7 @@
       }
     },
     "packages/lifetimes": {
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-eslint": "9.0.5",

--- a/packages/eslint-plugin/index.test.mts
+++ b/packages/eslint-plugin/index.test.mts
@@ -91,6 +91,15 @@ new RuleTester({ parser: "@typescript-eslint/parser" }).run(
         ],
       },
       {
+        code: "const a = /foo/g;",
+        parserOptions,
+        errors: [
+          {
+            messageId: "mayNotCreateStatefulRegexp",
+          },
+        ],
+      },
+      {
         code: "var a = true;",
         parserOptions,
         errors: [

--- a/packages/eslint-plugin/module-scope-allowlist.mts
+++ b/packages/eslint-plugin/module-scope-allowlist.mts
@@ -14,6 +14,7 @@ const MESSAGES = {
   mayNotCreateObject: `May not create mutable object in module scope. ${RECOMMENDATION}`,
   mayNotCreateArray: `May not create mutable array in module scope. ${RECOMMENDATION}`,
   mayNotCreateMutableVariable: `May not create mutable variable in module scope. ${RECOMMENDATION}`,
+  mayNotCreateStatefulRegexp: `May not create stateful (global or sticky) RegExp in module scope.`,
 } as const;
 
 type MessageIds = keyof typeof MESSAGES;
@@ -205,6 +206,18 @@ export default ESLintUtils.RuleCreator.withoutDocs({
           context.report({
             node,
             messageId: "mayNotCreateMutableVariable",
+          });
+        }
+      },
+      Literal(node: TSESTree.Literal) {
+        if (
+          context.getScope().type === "module" &&
+          "regex" in node &&
+          (node.regex.flags.includes("y") || node.regex.flags.includes("g"))
+        ) {
+          context.report({
+            node,
+            messageId: "mayNotCreateStatefulRegexp",
           });
         }
       },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifetimes/eslint-plugin",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "author": "Marcus Armstrong <marcusdarmstrong@gmail.com>",
   "homepage": "https://github.com/marcusdarmstrong/lifetimes",
   "repository": "github:marcusdarmstrong/lifetimes",

--- a/packages/lifetimes/package.json
+++ b/packages/lifetimes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lifetimes",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A utility for explicit specification and enforcement of module scope variable lifetimes",
   "license": "MIT",
   "author": "Marcus Armstrong <marcusdarmstrong@gmail.com>",


### PR DESCRIPTION
Changes:
- Typescript choking on use of `readOnly<ComponentType>(...)`
- Adds ESLint detection of mutable RegExp literals in module scope
- Adds runtime detection of mutable RegExp literals provided to `readOnly`
- Fixes `Map.prototype.size` and `Set.prototype.size` behavior